### PR TITLE
new: Allow to mark a link as read and read later

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -28,7 +28,17 @@ function search(url) {
     });
 }
 
+function markLinkAsRead(link) {
+    return http.post(`/links/${link.id}/read`);
+}
+
+function markLinkAsReadLater(link) {
+    return http.post(`/links/${link.id}/later`);
+}
+
 export default {
     authenticate,
     search,
+    markLinkAsRead,
+    markLinkAsReadLater,
 };

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -21,7 +21,11 @@ export const i18n = createI18n({
             "forms.error": "Error:",
             "link.invalid_protocol":
                 "This page cannot be handled by Flus (non-supported protocol).",
+            "link.is_read": "You read this link.",
+            "link.is_read_later": "This link is marked to be read later.",
             "link.loading": "Loading the link…",
+            "link.mark_as_read": "Mark as read",
+            "link.mark_as_read_later": "Read later",
             "loading.in_progress": "Loading in progress…",
             "login.email.label": "Email address",
             "login.errors.server_error":
@@ -59,7 +63,11 @@ export const i18n = createI18n({
             "forms.error": "Erreur :",
             "link.invalid_protocol":
                 "Cette page ne peut pas être enregistrée dans Flus (protocole non supporté).",
+            "link.is_read": "Vous avez lu ce lien.",
+            "link.is_read_later": "Ce lien est à lire plus tard.",
             "link.loading": "Chargement du lien…",
+            "link.mark_as_read": "Marquer comme lu",
+            "link.mark_as_read_later": "Lire plus tard",
             "loading.in_progress": "Chargement en cours…",
             "login.email.label": "Adresse courriel",
             "login.errors.server_error":

--- a/src/screens/LinkScreen.vue
+++ b/src/screens/LinkScreen.vue
@@ -4,19 +4,43 @@
 
 <template>
     <Screen :title="link.title" header>
-        <div v-if="ready && alert.type === ''">
-            <div class="flow flow--small">
+        <div v-if="ready && alert.type === ''" class="flow">
+            <div class="flow flow--smaller">
                 <h1 class="text--normal">
                     {{ link.title }}
                 </h1>
 
                 <p class="text--secondary">
                     {{ hostLabel }}&nbsp;·&nbsp;{{ readingTimeLabel }}
+
+                    <span v-if="link.isRead" :title="t('link.is_read')">
+                        <Icon name="check" />
+                    </span>
+
+                    <span v-if="link.isReadLater" :title="t('link.is_read_later')">
+                        <Icon name="bookmark" />
+                    </span>
                 </p>
 
                 <div v-if="tags">
                     <span v-for="tag in tags" class="tag badge badge--accent">#{{ tag }}</span>
                 </div>
+            </div>
+
+            <div class="cols cols--always cols--center cols--gap">
+                <button v-if="!link.isRead || link.isReadLater" class="button--icon button--small" @click.prevent="markAsRead">
+                    <Icon name="check" />
+                    <span class="sr-only">
+                        {{ t("link.mark_as_read") }}
+                    </span>
+                </button>
+
+                <button v-if="!link.isReadLater" class="button--icon button--small" @click.prevent="markAsReadLater">
+                    <Icon name="bookmark" />
+                    <span class="sr-only">
+                        {{ t("link.mark_as_read_later") }}
+                    </span>
+                </button>
             </div>
         </div>
 
@@ -74,6 +98,8 @@ const link = ref({
     url: "",
     readingTime: 0,
     tags: {},
+    isRead: false,
+    isReadLater: false,
 });
 
 const hostLabel = computed(() => {
@@ -131,6 +157,8 @@ async function refreshForCurrentTab() {
                 url: fetchedLink.url,
                 readingTime: fetchedLink.reading_time,
                 tags: fetchedLink.tags,
+                isRead: fetchedLink.is_read,
+                isReadLater: fetchedLink.is_read_later,
             };
 
             ready.value = true;
@@ -151,6 +179,33 @@ async function refreshForCurrentTab() {
             }
 
             ready.value = true;
+        });
+}
+
+async function markAsRead() {
+    api.markLinkAsRead(link.value)
+        .then((result) => {
+            link.value.isRead = true;
+            link.value.isReadLater = false;
+        })
+        .catch((error) => {
+            alert.value = {
+                type: "error",
+                message: t("errors.unknown"),
+            };
+        });
+}
+
+async function markAsReadLater() {
+    api.markLinkAsReadLater(link.value)
+        .then((result) => {
+            link.value.isReadLater = true;
+        })
+        .catch((error) => {
+            alert.value = {
+                type: "error",
+                message: t("errors.unknown"),
+            };
         });
 }
 


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Login with the extension
2. Open the extension on a page
3. Click on the read later button
4. Verify in the application that the link appears in the bookmarks
5. Click on the read button
6. Verify in the application that the link appears as read

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
