### PR TITLE
fix: Fix display of collections with a group

### DIFF
--- a/src/components/CollectionsSelector.vue
+++ b/src/components/CollectionsSelector.vue
@@ -119,25 +119,21 @@ const notSelectedCollectionsNoGroup = computed(() => {
 });
 
 const notSelectedCollectionsByGroup = computed(() => {
-    const collectionsByGroup = {};
+    const collectionsWithGroup = notSelectedCollections.value.filter((collection) => {
+        return collection.group !== null;
+    });
 
-    for (const collection of notSelectedCollections.value) {
-        if (collection.group === null) {
-            return;
-        }
+    const groupedCollections = Object.groupBy(collectionsWithGroup, (collection) => {
+        return collection.group;
+    });
 
-        if (collectionsByGroup[collection.group] == null) {
-            collectionsByGroup[collection.group] = [];
-        }
-
-        collectionsByGroup[collection.group].push(collection);
-    }
-
-    return Object.entries(collectionsByGroup);
+    return Object.entries(groupedCollections);
 });
 
 function setDefaultSelectedCollectionId() {
-    if (notSelectedCollections.value.length > 0) {
+    if (notSelectedCollectionsNoGroup.value.length > 0) {
+        newCollectionId.value = notSelectedCollectionsNoGroup.value[0].id;
+    } else if (notSelectedCollections.value.length > 0) {
         newCollectionId.value = notSelectedCollections.value[0].id;
     }
 }


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create several collections with and without a group
2. Open the extension and verify that all the collections are displayed

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both Firefox and Chrome
- [ ] Accessibility has been tested
- [ ] Translations are synchronized
- [ ] Copyright notices are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
