### PR TITLE
new: Allow to choose dark theme

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -21,6 +21,7 @@ export const i18n = createI18n({
             "errors.email.presence": "The email address is required.",
             "errors.language.invalid": "The language is invalid.",
             "errors.password.presence": "The password is required.",
+            "errors.theme.invalid": "The theme is invalid.",
             "errors.unknown":
                 "An unknown error has occurred. Please close and reopen the extension. If it still doesn’t work, please contact the support.",
             "errors.url.url": "The URL of the current page is not supported by Flus.",
@@ -62,6 +63,10 @@ export const i18n = createI18n({
             "notification.close": "Close the notification",
             "settings.language.label": "Interface language",
             "settings.submit": "Save",
+            "settings.theme.auto": "Auto",
+            "settings.theme.dark": "Dark",
+            "settings.theme.label": "Theme",
+            "settings.theme.light": "Light",
             "settings.title": "Settings",
         },
 
@@ -77,6 +82,7 @@ export const i18n = createI18n({
             "errors.email.presence": "L’adresse email est obligatoire.",
             "errors.language.invalid": "La langue est invalide.",
             "errors.password.presence": "Le mot de passe est obligatoire.",
+            "errors.theme.invalid": "Le thème est invalide.",
             "errors.unknown":
                 "Une erreur inconnue est survenue. Veuillez fermer et réouvrir l’extension. Si cela ne suffit pas, veuillez contacter le support.",
             "errors.url.url": "L’URL de la page actuelle n’est pas supportée par Flus.",
@@ -118,6 +124,10 @@ export const i18n = createI18n({
             "notification.close": "Fermer la notification",
             "settings.language.label": "Langue de l’interface",
             "settings.submit": "Sauvegarder",
+            "settings.theme.auto": "Auto",
+            "settings.theme.dark": "Sombre",
+            "settings.theme.label": "Thème",
+            "settings.theme.light": "Clair",
             "settings.title": "Paramètres",
         },
     },

--- a/src/screens/SettingsScreen.vue
+++ b/src/screens/SettingsScreen.vue
@@ -32,6 +32,29 @@
                 </select>
             </div>
 
+            <div class="flow flow--smaller">
+                <label for="settings-theme">
+                    {{ t('settings.theme.label') }}
+                </label>
+
+                <p v-if="form.isInvalid('theme')" id="settings-theme-error" class="form-group__error" role="alert">
+                    {{ t('forms.error') }}
+                    {{ form.error('theme') }}
+                </p>
+
+                <select
+                    id="settings-theme"
+                    required
+                    v-model.trim="theme"
+                    :aria-invalid="form.isInvalid('theme')"
+                    :aria-errormessage="form.isInvalid('theme') ? 'settings-theme-error' : null"
+                >
+                    <option value="auto">{{ t('settings.theme.auto') }}</option>
+                    <option value="light">{{ t('settings.theme.light') }}</option>
+                    <option value="dark">{{ t('settings.theme.dark') }}</option>
+                </select>
+            </div>
+
             <div class="text--center">
                 <button class="button--primary button--big" :disabled="form.inProgress() ? 'true' : null">
                     {{ t("settings.submit") }}
@@ -55,11 +78,19 @@ locale.value = store.locale;
 const title = t("settings.title");
 
 const language = ref(store.locale);
+const theme = ref(store.theme);
 
 watch(
     () => store.locale,
     (storeLocale) => {
         locale.value = storeLocale;
+    },
+);
+
+watch(
+    () => store.theme,
+    (storeTheme) => {
+        theme.value = storeTheme;
     },
 );
 
@@ -72,6 +103,17 @@ function save() {
         form.setAndFormatErrors(
             {
                 language: [{ code: "invalid" }],
+            },
+            t,
+        );
+    }
+
+    if (["auto", "light", "dark"].includes(theme.value)) {
+        store.setTheme(theme.value);
+    } else {
+        form.setAndFormatErrors(
+            {
+                theme: [{ code: "invalid" }],
             },
             t,
         );

--- a/src/store.js
+++ b/src/store.js
@@ -4,10 +4,14 @@
 import { reactive, watch, toRaw } from "vue";
 import browser from "webextension-polyfill";
 
+import { applyTheme } from "./theme.js";
+
 export const store = reactive({
     ready: false,
 
     locale: "fr",
+
+    theme: "auto",
 
     auth: {
         server: "https://app.flus.fr",
@@ -19,6 +23,10 @@ export const store = reactive({
 
     setLocale(locale) {
         this.locale = locale;
+    },
+
+    setTheme(theme) {
+        this.theme = theme;
     },
 
     rememberCredentials(server, email, token) {
@@ -49,7 +57,12 @@ export const store = reactive({
     },
 });
 
-browser.storage.local.get(["locale", "auth"]).then((results) => {
+browser.storage.local.get(["theme", "locale", "auth"]).then((results) => {
+    if (Object.hasOwn(results, "theme")) {
+        store.theme = results.theme;
+        applyTheme(store.theme);
+    }
+
     if (Object.hasOwn(results, "locale")) {
         store.setLocale(results.locale);
     }
@@ -73,5 +86,13 @@ watch(
     (locale) => {
         document.documentElement.setAttribute("lang", locale);
         browser.storage.local.set({ locale: toRaw(locale) });
+    },
+);
+
+watch(
+    () => store.theme,
+    (theme) => {
+        applyTheme(theme);
+        browser.storage.local.set({ theme: toRaw(theme) });
     },
 );

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,31 @@
+// This file is part of Flus Browser
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+const mediaQuery = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
+
+function handleColorSchemeChange(event) {
+    const colorScheme = event.matches ? "dark" : "light";
+    document.documentElement.dataset.colorScheme = colorScheme;
+}
+
+export function applyTheme(theme) {
+    let colorScheme = theme;
+
+    if (mediaQuery) {
+        mediaQuery.removeEventListener("change", handleColorSchemeChange);
+
+        if (theme === "auto") {
+            if (mediaQuery.matches) {
+                colorScheme = "dark";
+            } else {
+                colorScheme = "light";
+            }
+
+            mediaQuery.addEventListener("change", handleColorSchemeChange);
+        }
+    } else if (theme === "auto") {
+        colorScheme = "light";
+    }
+
+    document.documentElement.dataset.colorScheme = colorScheme;
+}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Open the extension and choose "dark" theme
2. When theme is "auto", verify it complies to the OS preferences

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
