### PR TITLE
new: Allow to open Flus in Firefox sidebar

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,6 +29,18 @@
             "suggested_key": {
                 "default": "Ctrl+Shift+1"
             }
+        },
+        "_execute_sidebar_action": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+2"
+            },
+            "description": "Open Flus in the sidebar"
         }
+    },
+
+    "sidebar_action": {
+        "default_icon": "icons/icon-32.png",
+        "default_panel": "sidebar/index.html",
+        "default_title": "Flus"
     }
 }

--- a/src/sidebar/index.html
+++ b/src/sidebar/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr" data-color-scheme="light">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="../stylesheets/application.css"/>
+        <script type="module" src="../application.js" defer></script>
+    </head>
+
+    <body>
+        <div class="sidebar" id="app"></div>
+    </body>
+</html>

--- a/src/stylesheets/application.css
+++ b/src/stylesheets/application.css
@@ -14,6 +14,10 @@ body {
     overflow: auto;
 }
 
+.sidebar {
+    height: 100vh;
+}
+
 .screen {
     display: flex;
     height: 100%;


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. In Firefox, open Flus in the sidebar (or press ctrl+maj+2)
2. Verify that it works correctly

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
