### PR TITLE
dev: Fix the Makefile to run on Firefox by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ watch: ## Watch and build the assets
 .PHONY: run
 run: BROWSER ?= firefox
 run: ## Run the extension in a browser (can take a BROWSER argument)
-ifeq ($(BROWSER),chromium)
-	npm run start:browser -- --target chromium
-else ifeq ($(BROWSER),firefox)
+ifeq ($(BROWSER), $(filter $(BROWSER), firefox))
 	npm run start:browser -- --target firefox-desktop
+else ifeq ($(BROWSER), $(filter $(BROWSER), chromium))
+	npm run start:browser -- --target chromium
 else
 	npm run start:browser -- --target firefox-android --android-device $(BROWSER)
 endif


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. execute `make run`
2. verify that it runs the extension on Firefox

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on Firefox (popup and sidebar), Firefox Mobile and Chrome
- [ ] Accessibility has been tested
- [ ] Translations are synchronized
- [ ] Copyright notices are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
