### PR TITLE
fix: Fix closing extension on Firefox mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,13 +3,33 @@
   -->
 
 <template>
-    <component v-if="store.ready" :is="currentView" />
-    <LoadingScreen v-else />
+    <component :is="screen" />
 </template>
 
 <script setup>
+import { computed } from "vue";
+
 import { store } from "./store.js";
-import { currentView } from "./router.js";
+import { requireAuth, isAuthenticated } from "./auth.js";
+import { currentScreen } from "./router.js";
 
 import LoadingScreen from "./screens/LoadingScreen.vue";
+import LoginScreen from "./screens/LoginScreen.vue";
+import NotFoundScreen from "./screens/NotFoundScreen.vue";
+
+const screen = computed(() => {
+    if (!store.ready) {
+        return LoadingScreen;
+    }
+
+    if (currentScreen.value == null) {
+        return NotFoundScreen;
+    }
+
+    if (requireAuth() && !isAuthenticated()) {
+        return LoginScreen;
+    }
+
+    return currentScreen.value;
+});
 </script>

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,9 +1,7 @@
 // This file is part of Flus Browser
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { watch } from "vue";
-
-import { redirect } from "./router.js";
+import { currentPath } from "./router.js";
 import { store } from "./store.js";
 
 export function isAuthenticated() {
@@ -11,35 +9,5 @@ export function isAuthenticated() {
 }
 
 export function requireAuth() {
-    const redirectPath = "/login";
-
-    if (!isAuthenticated()) {
-        redirect(redirectPath);
-    }
-
-    watch(
-        () => store.auth.token,
-        (token) => {
-            if (token.length === 0) {
-                redirect(redirectPath);
-            }
-        },
-    );
-}
-
-export function requireNotAuth() {
-    const redirectPath = "/";
-
-    if (isAuthenticated()) {
-        redirect(redirectPath);
-    }
-
-    watch(
-        () => store.auth.token,
-        (token) => {
-            if (token.length > 0) {
-                redirect(redirectPath);
-            }
-        },
-    );
+    return currentPath.value === "/";
 }

--- a/src/http.js
+++ b/src/http.js
@@ -16,7 +16,7 @@ function handleErrors(response) {
     if (response.status === 401) {
         store.logout();
         store.notify("error", t("errors.auth.invalid_token"));
-        redirect("/login");
+        redirect("/");
     } else if (!response.ok) {
         throw new HttpError(response.status, response.data);
     }

--- a/src/router.js
+++ b/src/router.js
@@ -6,24 +6,26 @@ import { ref, computed } from "vue";
 import LinkScreen from "./screens/LinkScreen.vue";
 import LoginScreen from "./screens/LoginScreen.vue";
 import MenuScreen from "./screens/MenuScreen.vue";
-import NotFoundScreen from "./screens/NotFoundScreen.vue";
 import SettingsScreen from "./screens/SettingsScreen.vue";
 
 const routes = {
     "/": LinkScreen,
-    "/login": LoginScreen,
     "/menu": MenuScreen,
     "/settings": SettingsScreen,
 };
 
-const currentPath = ref(window.location.hash);
+const currentHash = ref(window.location.hash);
 
 window.addEventListener("hashchange", () => {
-    currentPath.value = window.location.hash;
+    currentHash.value = window.location.hash;
 });
 
-export const currentView = computed(() => {
-    return routes[currentPath.value.slice(1) || "/"] || NotFoundScreen;
+export const currentPath = computed(() => {
+    return currentHash.value.slice(1) || "/";
+});
+
+export const currentScreen = computed(() => {
+    return routes[currentPath.value];
 });
 
 export function redirect(path) {

--- a/src/screens/LinkScreen.vue
+++ b/src/screens/LinkScreen.vue
@@ -97,11 +97,10 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import browser from "webextension-polyfill";
 
-import { requireAuth, isAuthenticated } from "../auth.js";
 import { store } from "../store.js";
 import api from "../api.js";
 import http from "../http.js";
@@ -109,8 +108,6 @@ import collectionsForm from "../form.js";
 import { link, host, readingTime } from "../models/link.js";
 import CollectionsSelector from "../components/CollectionsSelector.vue";
 import Notes from "../components/Notes.vue";
-
-requireAuth();
 
 const { t, locale } = useI18n();
 locale.value = store.locale;
@@ -227,7 +224,5 @@ function removeCollection(collection) {
         });
 }
 
-if (isAuthenticated()) {
-    onMounted(refreshForCurrentTab);
-}
+onMounted(refreshForCurrentTab);
 </script>

--- a/src/screens/LoginScreen.vue
+++ b/src/screens/LoginScreen.vue
@@ -120,15 +120,12 @@
 import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
 
-import { requireNotAuth } from "../auth.js";
 import { store } from "../store.js";
 import api from "../api.js";
 import form from "../form.js";
 import http from "../http.js";
 
 import logo from "url:../images/logo.svg";
-
-requireNotAuth();
 
 const { t, locale } = useI18n();
 locale.value = store.locale;

--- a/src/screens/MenuScreen.vue
+++ b/src/screens/MenuScreen.vue
@@ -41,6 +41,6 @@ const title = t("menu.title");
 
 function logout() {
     store.logout();
-    redirect("/login");
+    redirect("/");
 }
 </script>


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Open the extension on Firefox mobile
2. Login
3. Go back to close the extension
4. Verify that the extension is closed

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on Firefox (popup and sidebar), Firefox Mobile and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
