### PR TITLE
feat: Allow to open shortcuts edition page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,19 @@ watch: ## Watch and build the assets
 run: BROWSER ?= firefox
 run: ## Run the extension in a browser (can take a BROWSER argument)
 ifeq ($(BROWSER), $(filter $(BROWSER), firefox))
-	npm run start:browser -- --target firefox-desktop --firefox-profile ./profile-firefox
+	npm run start:browser -- \
+		--target firefox-desktop \
+		--firefox-profile ./profile-firefox \
+		--profile-create-if-missing \
+		--keep-profile-changes \
+		--url=https://flus.fr
 else ifeq ($(BROWSER), $(filter $(BROWSER), chromium))
-	npm run start:browser -- --target chromium --chromium-profile ./profile-chromium
+	npm run start:browser -- \
+		--target chromium \
+		--chromium-profile ./profile-chromium \
+		--profile-create-if-missing \
+		--keep-profile-changes \
+		--url=https://flus.fr
 else
 	npm run start:browser -- --target firefox-android --android-device $(BROWSER)
 endif

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:assets": "parcel build --dist-dir dist/assets src/manifest.json",
     "build:artifact": "web-ext build --source-dir dist/assets --artifacts-dir dist/artifacts --overwrite-dest",
     "start:watcher": "parcel watch --no-hmr --no-autoinstall --dist-dir dist/dev_assets src/manifest.json",
-    "start:browser": "web-ext run --source-dir dist/dev_assets --devtools --profile-create-if-missing --keep-profile-changes --url=https://flus.fr",
+    "start:browser": "web-ext run --source-dir dist/dev_assets --devtools",
     "lint:webext": "web-ext lint --source-dir dist/assets",
     "lint:biome": "biome lint --error-on-warnings --config-path=.biome.json && biome format --error-on-warnings --config-path=.biome.json"
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,25 @@
+// This file is part of Flus Browser
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import browser from "webextension-polyfill";
+
+export async function getBrowserName() {
+    if (browser.runtime.getBrowserInfo == null) {
+        // Chrome doesn't provide this function.
+        // See https://issues.chromium.org/issues/40671645
+        return "chrome";
+    } else {
+        const info = await browser.runtime.getBrowserInfo();
+        return info.name.toLowerCase();
+    }
+}
+
+export async function isFirefox() {
+    const browserName = await getBrowserName();
+    return browserName === "firefox";
+}
+
+export async function isChrome() {
+    const browserName = await getBrowserName();
+    return browserName === "chrome";
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -53,6 +53,7 @@ export const i18n = createI18n({
             "menu.open": "Open the menu",
             "menu.open_flus": "Open Flus",
             "menu.settings": "Settings",
+            "menu.shortcuts": "Keyboard shortcuts",
             "menu.title": "Menu",
             "not_found.back": "Back",
             "not_found.details":
@@ -117,6 +118,7 @@ export const i18n = createI18n({
             "menu.open": "Ouvrir le menu",
             "menu.open_flus": "Ouvrir Flus",
             "menu.settings": "Paramètres",
+            "menu.shortcuts": "Raccourcis clavier",
             "menu.title": "Menu",
             "not_found.back": "Retour",
             "not_found.details":

--- a/src/screens/LoginScreen.vue
+++ b/src/screens/LoginScreen.vue
@@ -126,6 +126,7 @@ import { store } from "../store.js";
 import api from "../api.js";
 import form from "../form.js";
 import http from "../http.js";
+import * as tabs from "../tabs.js";
 
 import logo from "url:../images/logo.svg";
 
@@ -174,8 +175,6 @@ function login() {
 }
 
 function openRegistrationPage() {
-    browser.tabs.create({
-        url: registrationUrl.value,
-    });
+    tabs.open(registrationUrl.value);
 }
 </script>

--- a/src/screens/MenuScreen.vue
+++ b/src/screens/MenuScreen.vue
@@ -17,6 +17,12 @@
                 </a>
             </li>
 
+            <li v-if="shouldShowShortcuts">
+                <a href="#" class="button button--big button--ghost" @click="openShortcuts">
+                    {{ t("menu.shortcuts") }}
+                </a>
+            </li>
+
             <li v-if="isAuthenticated()">
                 <button @click="logout" class="button--big button--ghost">
                     {{ t("menu.logout") }}
@@ -27,6 +33,7 @@
 </template>
 
 <script setup>
+import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import browser from "webextension-polyfill";
 
@@ -34,6 +41,8 @@ import { isAuthenticated } from "../auth.js";
 import { store } from "../store.js";
 import { redirect } from "../router.js";
 import api from "../api.js";
+import * as browserUtils from "../browser.js";
+import * as tabs from "../tabs.js";
 
 const { t, locale } = useI18n();
 locale.value = store.locale;
@@ -46,4 +55,19 @@ function logout() {
         redirect("/");
     });
 }
+
+async function openShortcuts() {
+    if (await browserUtils.isChrome()) {
+        tabs.open("chrome://extensions/shortcuts");
+    } else {
+        browser.commands.openShortcutSettings();
+    }
+}
+
+const shouldShowShortcuts = ref(false);
+
+onMounted(async () => {
+    shouldShowShortcuts.value =
+        (await browserUtils.isChrome()) || browser.commands.openShortcutSettings != null;
+});
 </script>

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -1,0 +1,8 @@
+// This file is part of Flus Browser
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import browser from "webextension-polyfill";
+
+export function open(url) {
+    browser.tabs.create({ url });
+}


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Open the menu of the extension
2. Click on "Keyboard shortcuts" (note: it shouldn't appear on Firefox mobile)
3. Verify that you are redirected on the browser keyboard shortcuts edition page

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on Firefox (popup and sidebar), Firefox Mobile and Chrome
- [x] Accessibility has been tested
- [x] Translations are synchronized
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
